### PR TITLE
Add tide and tide-scheduler plugins to the registry

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -6,5 +6,13 @@
     "service-discovery": {
         "source": "containership.plugin.service-discovery",
         "description": "A service discovery plugin for ContainerShip"
+    },
+    "tide": {
+        "source": "containership.plugin.tide",
+        "description": "A CLI plugin for managing tide-scheduler jobs on ContainerShip"
+    },
+    "tide-scheduler": {
+        "source": "containership.plugin.tide-scheduler",
+        "description": "A cron-like job scheduler for ContainerShip"
     }
 }


### PR DESCRIPTION
Adds the `tide` and `tide-scheduler` plugins to the publicly searchable registry, making them available for download from the CLI.